### PR TITLE
Add a vcs and plugin installation scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea
 /.psh.yaml
+/.psh.yaml.override
 /shopware
 
 # dev-ops
@@ -8,3 +9,5 @@
 /dev-ops/docker/containers/php7/createuser.sh
 /dev-ops/docker/_volumes
 !dev-ops/docker/_volumes/.gitkeep
+/plugins/
+!/plugins/.gitkeep

--- a/.psh.yaml.dist
+++ b/.psh.yaml.dist
@@ -7,6 +7,7 @@ const:
   DB_HOST: "mysql"
   DB_NAME: "shopware"
   SW_HOST: "10.100.111.46"
+  SW-BRANCH: "5.3"
   SW-VERSION: "latest"
 
 dynamic:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ If you want an older shopware version just add --sw-version to the init script:
 
     $ ./psh.phar init --sw-version=5.2.26
 
+#### For plugin development
+
+For plugin development there is a script `init-vcs` to initialize and install shopware through github.  
+
+    $ ./psh.phar init-vcs --sw-branch=5.2
+
+The plugin(s) you want to start development should be located in `./plugins` (Only new plugin system is supported). They can be installed and linked into the Shopware checkout by executing
+
+    $ ./psh.phar init-plugins
+    
+
+This can be used together with our [`plugin-dev-tools`](https://github.com/shopwareLabs/plugin-dev-tools) as the `local` environment.
+
+#### Access
 
 Configure your online store in a web browser with the credentials demo/demo:
 

--- a/dev-ops/common/actions/init-plugins.sh
+++ b/dev-ops/common/actions/init-plugins.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#DESCRIPTION: executes on app_webserver to install the local plugins
+
+I: find shopware/custom/plugins/ -type l | xargs rm
+ls plugins/ | while read file; do ln -s ../../../plugins/$file shopware/custom/plugins/$file; done
+shopware/bin/console sw:plugin:refresh
+shopware/bin/console sw:plugin:list
+I: ls plugins/ | while read file; do shopware/bin/console sw:plugin:uninstall $file; done;
+ls plugins/ | while read file; do shopware/bin/console sw:plugin:install --activate $file; done;

--- a/dev-ops/common/actions/init-vcs.sh
+++ b/dev-ops/common/actions/init-vcs.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#DESCRIPTION: executes on app_webserver to provision a vcs environment
+
+rm -rf ./shopware
+git clone --depth 1 -b __SW-BRANCH__ https://github.com/shopware/shopware.git
+
+cd shopware/ && composer install && composer dump-autoload --optimize
+
+ant -f shopware/build/build.xml -Ddb.user=__DB_USER__ -Ddb.password=__DB_PASSWORD__ -Ddb.host=__DB_HOST__ -Ddb.name=__DB_NAME__ -Dapp.host=__SW_HOST__ build-cache-dir build-config build-database build-generate-attributes build-snippets-deploy build-theme-initialize build-create-admin-account build-install-lock-file build-disable-firstrunwizard install-git-hooks
+
+shopware/bin/console sw:firstrunwizard:disable

--- a/dev-ops/docker/containers/php7/Dockerfile
+++ b/dev-ops/docker/containers/php7/Dockerfile
@@ -26,7 +26,8 @@ RUN apt-get update -qq && apt-get install -y -qq \
         vim \
         graphviz \
         netcat-openbsd \
-        nodejs npm nodejs-legacy
+        nodejs npm nodejs-legacy \
+        ant
 
 RUN docker-php-ext-install iconv mcrypt mbstring \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \


### PR DESCRIPTION
enable minimal plugin development/testing capabilities

* VCS because the release does not come with the testing directories
* `./plugins` directory so replacing sw with a different version does not remove the plugin