### PR TITLE
Removed breaking RUN command

### DIFF
--- a/dev-ops/docker/containers/php7/Dockerfile
+++ b/dev-ops/docker/containers/php7/Dockerfile
@@ -1,9 +1,5 @@
 FROM php:7.1-apache
 
-RUN apt-get update -qq && apt-get install -y -qq apt-utils && mkdir -p /usr/share/man/man1 \
-    && apt-get update -qq && apt-get install -y -qq openjdk-8-jre-headless \
-    && apt-get update -qq && apt-get install -y -qq  openjdk-8-jdk && dpkg --configure -a
-
 RUN apt-get update -qq && apt-get install -y -qq \
         libicu-dev \
         libfreetype6-dev \


### PR DESCRIPTION
The debian version does not natively support these two packages (openjdk) and the command will fail.