### PR TITLE
added behind proxy support for pear/pecl.

### DIFF
--- a/dev-ops/docker/containers/php7/Dockerfile
+++ b/dev-ops/docker/containers/php7/Dockerfile
@@ -41,6 +41,8 @@ RUN docker-php-ext-install iconv mcrypt mbstring opcache \
     && docker-php-ext-install pdo \
     && docker-php-ext-install pdo_mysql
 
+RUN pear config-set http_proxy $http_proxy
+
 RUN pecl install apcu
 RUN echo "extension=apcu.so" > /usr/local/etc/php/conf.d/apcu.ini
 


### PR DESCRIPTION
Hi,

even though we've set `http_proxy` and `HTTP_PROXY` environmant variables and properly configured `docker` to use it, PECL and PEAR won't use the value of them.

Behind a firewall this can result in the following error message during `./psh.phar docker:start`:

```
Step 6/33 : RUN pecl install apcu
         ---> Running in 7230bb8fe17e
        No releases available for package "pecl.php.net/apcu"
        install failed
        Service 'app_server' failed to build: The command '/bin/sh -c pecl install apcu' returned a non-zero code: 1

Execution aborted, a subcommand failed!
```

Please note that i can not verify the behavior of this fix without a proxy in front of me... it should, as far as i know from the docs of PEAR.

The change in this PR might fix the issue, but maybe there is a more elegant way to fix this? 

