### PR TITLE
Removes unneeded networking information for Docker

### DIFF
--- a/.psh.yaml.dist
+++ b/.psh.yaml.dist
@@ -6,7 +6,7 @@ const:
   DB_PASSWORD: "app"
   DB_HOST: "mysql"
   DB_NAME: "shopware"
-  SW_HOST: "10.100.111.46"
+  SW_HOST: "app_server"
   SW-BRANCH: "5.4"
   SW-VERSION: "latest"
 

--- a/dev-ops/common/ConfigHelper.php
+++ b/dev-ops/common/ConfigHelper.php
@@ -14,7 +14,7 @@ class ConfigHelper
             'number_of_shards' => null,
             'client' => [
                 'hosts' => [
-                    '10.100.111.48:9200',
+                    'app_es:9200',
                 ],
             ],
         ];

--- a/dev-ops/docker/containers/php7/server-apache2-vhosts.conf
+++ b/dev-ops/docker/containers/php7/server-apache2-vhosts.conf
@@ -1,10 +1,7 @@
 <VirtualHost *:80>
-   ServerName "10.100.111.46"
-   ServerAlias "127.0.0.1"
    DocumentRoot /var/www/shopware/shopware/
 
-   SetEnvIf Host "10.100.111.46" SHOPWARE_ENV=dev
-   SetEnvIf Host "127.0.0.1" SHOPWARE_ENV=test
+   SetEnv SHOPWARE_ENV=dev
 
    <Directory /var/www/shopware/shopware/>
       Options Indexes FollowSymLinks MultiViews

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,6 @@ services:
       COMPOSER_CACHE_DIR: /var/www/composer-cache-dir
     ports:
       - "8083:80"
-    networks:
-      sw_docker:
-        ipv4_address: 10.100.111.46
 
   app_mysql:
     build: dev-ops/docker/containers/mysql
@@ -26,9 +23,6 @@ services:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_USER: app
       MYSQL_PASSWORD: app
-    networks:
-      sw_docker:
-        ipv4_address: 10.100.111.47
 
   app_es:
     build: dev-ops/docker/containers/elastic-search
@@ -41,23 +35,8 @@ services:
     environment:
       TERM: xterm
       ES_JAVA_OPTS: "-Xmx256m -Xms256m"
-    networks:
-      sw_docker:
-        ipv4_address: 10.100.111.48
 
   app_redis:
     build: dev-ops/docker/containers/redis
     volumes:
       - ./dev-ops/docker/_volumes/app-redisdata:/data:Z
-    networks:
-      sw_docker:
-        ipv4_address: 10.100.111.49
-
-networks:
-  sw_docker:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-      - subnet: 10.100.111.0/24
-        gateway: 10.100.111.1


### PR DESCRIPTION
Did these changes to get Shopware to run locally on my Mac. The only other fix I had to do was enter the MySQL Docker to drop the hardcoded IP. I suspect this was done on the initial setup, but didn't bother to check.
Steps to fix that:
`docker exec -it shopware-docker_app_mysql_1 bash`

```
# mysql -u app -p
mysql > use shopware
mysql > `UPDATE `s_core_shops` SET `host`=NULL;
```

Should fix Issue #2 