### PR TITLE
set php version to 7.2

### DIFF
--- a/dev-ops/docker/containers/php7/Dockerfile
+++ b/dev-ops/docker/containers/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM webdevops/php-apache-dev:7.1
+FROM webdevops/php-apache-dev:7.2
 
 ENV COMPOSER_HOME=/.composer
 ENV WEB_DOCUMENT_ROOT=/var/www/shopware/shopware


### PR DESCRIPTION
Therefore the used Shopware 5 Version requires PHP 7.2 i pulled up the version, test it and it worked.